### PR TITLE
Redirect to 404 if url is not valid

### DIFF
--- a/client/components/lesson/LessonView.jsx
+++ b/client/components/lesson/LessonView.jsx
@@ -5,17 +5,30 @@ var _ = require('lodash');
 var Actions = require('../../actions');
 var LessonStore = require('../../stores/lesson-store.js');
 var Reflux = require('reflux');
-//var Constrainable = require('rnr-constrained-route');
+var Router = require('react-router');
+var Navigation = Router.Navigation;
 
 var LessonView = React.createClass({
-  
+
+  mixins: [Router.Navigation, Reflux.connect(LessonStore)],
+
   contextTypes: {
     router: React.PropTypes.func
   },
 
   componentWillMount: function(){
-    Actions.fetchLesson(this.context.router.getCurrentParams().url)
-    Actions.followLesson(this.context.router.getCurrentParams().url)
+    var self=this;
+    Actions.fetchLesson({sourceComponent: this, url: this.context.router.getCurrentParams().url})
+    .then(function(res){
+      Actions.followLesson(self.context.router.getCurrentParams().url)
+    })
+   
+
+    // if(this.state.lesson){
+    //   Actions.followLesson(this.context.router.getCurrentParams().url)
+    // }else{
+    //   this.transitionTo('/404');
+    // }
   },
 
   render: function() {

--- a/client/routes.js
+++ b/client/routes.js
@@ -36,6 +36,7 @@ var routes = (
         <Route path='/multiplechoice' handler={MultiChoiceCreation} />
         <Route path='/truefalse' handler={TrueFalseCreation} />
         <Route path='/shortanswer' handler={ShortAnswerCreation} />
+        <Route path='/404' handler={NotFound}/>
         <Route path='/:url' handler={LessonView} />
         <NotFoundRoute handler={NotFound}/>
       </Route>

--- a/client/stores/lesson-store.js
+++ b/client/stores/lesson-store.js
@@ -3,18 +3,23 @@ var Api = require('../utils/api');
 var Actions = require('../actions');
 var _ = require('lodash');
 
+
 module.exports = Reflux.createStore({
   listenables: [Actions],
 
   init: function() {},
 
-  fetchLesson : function(url){
-    url = url// || 'sass-101'
+
+  fetchLesson : function(payload){
+    var url = payload.url// || 'sass-101'
     var self = this;
     Api.getLesson(url)
     .then(function(res) {
       self.lesson = res.data;
       self.trigger(self.lesson);
+    })
+    .catch(function(res){
+      payload.sourceComponent.transitionTo('/404');
     })
   },
 


### PR DESCRIPTION
This is the react-router guide I used to make this happen (implemented the first option):
https://goo.gl/A50TTF

"Oftentimes your actions need to call transitionTo on the router, you can't just require your router instance as a module into your actions because your routes require views which also require the actions, creating a cycle indirectly.

router.js -> routes.js -> SomeComponent.js -> actions.js -> router.js

To avoid this, you can do one of three things:

Send the component to the action, think of it like event.target in DOM events if it bothers you."
